### PR TITLE
Using jq instead of custom sed-function and file replacement

### DIFF
--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -21,7 +21,8 @@ RUN apk -U upgrade \
         curl \
         openjdk17-jre-headless \
         ffmpeg \
-        unzip
+        unzip \
+        jq
 
 WORKDIR /jdownloader
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -116,14 +116,18 @@ mkdir -p ./update/versioninfo/JD
 echo '["eventscripter"]' > ./update/versioninfo/JD/extensions.requestedinstalls.json
 
 # Setup autoupdate script
-cfgDir="./cfg/"
+cfgDir="./cfg"
 
 autoUpdateEventScripterSettings="org.jdownloader.extensions.eventscripter.EventScripterExtension.json"
-jq '.freshinstall = false | .enabled = true' $cfgDir$autoUpdateEventScripterSettings > temp.json && mv temp.json $cfgDir$autoUpdateEventScripterSettings
+cp -n "./$autoUpdateEventScripterSettings" "$cfgDir/$autoUpdateEventScripterSettings"
+log "Modify JSON for EventScripter settings"
+jq '.freshinstall = false | .enabled = true' "$cfgDir/$autoUpdateEventScripterSettings" > temp.json && mv temp.json "$cfgDir/$autoUpdateEventScripterSettings"
 
 autoUpdateEventScripterScript="org.jdownloader.extensions.eventscripter.EventScripterExtension.scripts.json"
 autoUpdateEventScripterScriptFilter='if any(.[]; .name == "Auto-Update") then . else . + [{"eventTrigger": "INTERVAL", "enabled": true, "name": "Auto-Update", "script": "disablePermissionChecks(); if (callAPI(\"update\", \"isUpdateAvailable\") && isDownloadControllerIdle() && !callAPI(\"linkcrawler\", \"isCrawling\") && !callAPI(\"linkgrabberv2\", \"isCollecting\") && !callAPI(\"extraction\", \"getQueue\").length > 0) { callAPI(\"update\", \"restartAndUpdate\"); }", "eventTriggerSettings": {"lastFire": 1594799412187, "interval": 43200000, "isSynchronous": false}, "id": 1594796988140}] end'
-jq "$autoUpdateEventScripterScriptFilter" $cfgDir$autoUpdateEventScripterScript > temp.json && mv temp.json $cfgDir$autoUpdateEventScripterScript
+cp -n "./$autoUpdateEventScripterScript" "$cfgDir/$autoUpdateEventScripterScript"
+log "Modify JSON for EventScripter scripts"
+jq "$autoUpdateEventScripterScriptFilter" "$cfgDir/$autoUpdateEventScripterScript" > temp.json && mv temp.json "$cfgDir/$autoUpdateEventScripterScript"
 
 log "Start JDownloader"
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -115,11 +115,15 @@ unset JD_PASSWORD
 mkdir -p ./update/versioninfo/JD
 echo '["eventscripter"]' > ./update/versioninfo/JD/extensions.requestedinstalls.json
 
-# Put setup autoupdate script
+# Setup autoupdate script
+cfgDir="./cfg/"
+
 autoUpdateEventScripterSettings="org.jdownloader.extensions.eventscripter.EventScripterExtension.json"
+jq '.freshinstall = false | .enabled = true' $cfgDir$autoUpdateEventScripterSettings > temp.json && mv temp.json $cfgDir$autoUpdateEventScripterSettings
+
 autoUpdateEventScripterScript="org.jdownloader.extensions.eventscripter.EventScripterExtension.scripts.json"
-cp "./$autoUpdateEventScripterSettings" "./cfg/$autoUpdateEventScripterSettings"
-cp "./$autoUpdateEventScripterScript" "./cfg/$autoUpdateEventScripterScript"
+autoUpdateEventScripterScriptFilter='if any(.[]; .name == "Auto-Update") then . else . + [{"eventTrigger": "INTERVAL", "enabled": true, "name": "Auto-Update", "script": "disablePermissionChecks(); if (callAPI(\"update\", \"isUpdateAvailable\") && isDownloadControllerIdle() && !callAPI(\"linkcrawler\", \"isCrawling\") && !callAPI(\"linkgrabberv2\", \"isCollecting\") && !callAPI(\"extraction\", \"getQueue\").length > 0) { callAPI(\"update\", \"restartAndUpdate\"); }", "eventTriggerSettings": {"lastFire": 1594799412187, "interval": 43200000, "isSynchronous": false}, "id": 1594796988140}] end'
+jq "$autoUpdateEventScripterScriptFilter" $cfgDir$autoUpdateEventScripterScript > temp.json && mv temp.json $cfgDir$autoUpdateEventScripterScript
 
 log "Start JDownloader"
 

--- a/org.jdownloader.extensions.eventscripter.EventScripterExtension.scripts.json
+++ b/org.jdownloader.extensions.eventscripter.EventScripterExtension.scripts.json
@@ -1,8 +1,8 @@
 [{
   "eventTrigger": "INTERVAL",
   "enabled": true,
-  "name": "Auto-update",
-  "script": "disablePermissionChecks(); if (callAPI('update', 'isUpdateAvailable') && isDownloadControllerIdle() && !callAPI('linkcrawler', 'isCrawling') && !callAPI('linkgrabberv2', 'isCollecting') && !callAPI('extraction', 'getQueue').length > 0) { callAPI('update', 'restartAndUpdate'); }",
+  "name": "Auto-Update",
+  "script": "disablePermissionChecks(); if (callAPI(\"update\", \"isUpdateAvailable\") && isDownloadControllerIdle() && !callAPI(\"linkcrawler\", \"isCrawling\") && !callAPI(\"linkgrabberv2\", \"isCollecting\") && !callAPI(\"extraction\", \"getQueue\").length > 0) { callAPI(\"update\", \"restartAndUpdate\"); }"
   "eventTriggerSettings": {
     "lastFire": 1594799412187,
     "interval": 43200000,

--- a/org.jdownloader.extensions.eventscripter.EventScripterExtension.scripts.json
+++ b/org.jdownloader.extensions.eventscripter.EventScripterExtension.scripts.json
@@ -2,7 +2,7 @@
   "eventTrigger": "INTERVAL",
   "enabled": true,
   "name": "Auto-Update",
-  "script": "disablePermissionChecks(); if (callAPI(\"update\", \"isUpdateAvailable\") && isDownloadControllerIdle() && !callAPI(\"linkcrawler\", \"isCrawling\") && !callAPI(\"linkgrabberv2\", \"isCollecting\") && !callAPI(\"extraction\", \"getQueue\").length > 0) { callAPI(\"update\", \"restartAndUpdate\"); }"
+  "script": "disablePermissionChecks(); if (callAPI(\"update\", \"isUpdateAvailable\") && isDownloadControllerIdle() && !callAPI(\"linkcrawler\", \"isCrawling\") && !callAPI(\"linkgrabberv2\", \"isCollecting\") && !callAPI(\"extraction\", \"getQueue\").length > 0) { callAPI(\"update\", \"restartAndUpdate\"); }",
   "eventTriggerSettings": {
     "lastFire": 1594799412187,
     "interval": 43200000,

--- a/setup.sh
+++ b/setup.sh
@@ -12,30 +12,6 @@ email=$1
 password=$2
 devicename=$3
 
-# Replace a JSON value by searching its field in a JSON file
-# Usage : replaceJsonValue file field value
-replaceJsonValue()
-{
-    file=$1
-    field=$(printf "%s" "$2" | sed -e 's/\\/\\\\/g' -e 's/[]\/$*.^[]/\\&/g') # this field will be compared to a value from a json file, so we need to double escape the backslashes \\\\    And this field will be used in a sed regex, so we escape regex special characters ]\/$*.^[
-    newValue=$(printf "%s" "$3" | sed -e 's/[\/&]/\\&/g' -e 's/"/\\\\"/g') # this value will be used in a sed replace, so we escape replace special characters \/&    And this value will be stored in a json file, so finally we double escape the quotes \\\\"
-
-    fieldPart="\($field\)" # match the field
-    valuePart="\([^\\\"]\|\\\\.\)*" # match the value. This looks complicated because it can contain escaped quotes \" because of json format.
-
-    search="\"$fieldPart\"\s*:\s*\"$valuePart\""
-    replace="\"\1\":\"$newValue\""
-
-    sed -i "s/$search/$replace/g" $file
-    sedExitCode=$?
-
-    if [ $sedExitCode -ne 0 ]
-    then
-        log "ERROR" "sed exited with code '$sedExitCode'"
-        exit $sedExitCode
-    fi
-}
-
 cfgDir="./cfg/"
 
 # If JDownloader cfg directory does not exist
@@ -82,17 +58,17 @@ fi
 if [ -n "$email" ]
 then
     log "Replace JDownloader email in myJDownloader settings file"
-    replaceJsonValue $myJDownloaderSettingsFile "email" "$email"
+    jq --arg email $email '.email = $email' $myJDownloaderSettingsFile > temp.json && mv temp.json $myJDownloaderSettingsFile
 fi
 
 if [ -n "$password" ]
 then
     log "Replace JDownloader password in myJDownloader settings file"
-    replaceJsonValue $myJDownloaderSettingsFile "password" "$password"
+    jq --arg password $password '.password = $password' $myJDownloaderSettingsFile > temp.json && mv temp.json $myJDownloaderSettingsFile
 fi
 
 if [ -n "$devicename" ]
 then
     log "Replace JDownloader devicename in myJDownloader settings file"
-    replaceJsonValue $myJDownloaderSettingsFile "devicename" "$devicename"
+    jq --arg devicename $devicename '.devicename = $devicename' $myJDownloaderSettingsFile > temp.json && mv temp.json $myJDownloaderSettingsFile
 fi

--- a/ubuntu.Dockerfile
+++ b/ubuntu.Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update \
         openjdk-17-jre-headless \
         ffmpeg \
         unzip \
+        jq \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /jdownloader


### PR DESCRIPTION
I'm using iOS app with some push notifications.
Push notifications are based on eventscripter.

As you replace the json for eventscripter scripts on any container start, eventscripts for push notification were overwritten.
We can avoid this using jq instead of replacing files. As a benefit I removed your custom sed-function for myJD-json and implemented jq as well.