### PR TITLE
Add seperate folder for entrypoint

### DIFF
--- a/Dockerfile/alpine.Dockerfile
+++ b/Dockerfile/alpine.Dockerfile
@@ -18,7 +18,7 @@ ENV UMASK=""
 
 ARG OPENJDK="openjdk21-jre-headless"
 
-RUN apk add --no-cache --no-install-recommends \
+RUN apk add --no-cache \
         --repository=https://dl-cdn.alpinelinux.org/alpine/v$(cut -d. -f1,2 /etc/alpine-release)/community/ \
         bash \
         curl \
@@ -27,9 +27,10 @@ RUN apk add --no-cache --no-install-recommends \
         ${OPENJDK}
 
 RUN mkdir -p -m 777 /jdownloader/ && chown 1000:100 /jdownloader/
+RUN mkdir -p -m 777 /init/ && chown 1000:100 /init/
 
-COPY --chown=1000:100 --chmod=777 ./src/ /jdownloader/
+COPY --chown=1000:100 --chmod=777 ./src/ /init/
 
-WORKDIR /jdownloader/
+WORKDIR /init/
 
 ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/Dockerfile/debian-trixie.Dockerfile
+++ b/Dockerfile/debian-trixie.Dockerfile
@@ -30,9 +30,10 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 RUN mkdir -p -m 777 /jdownloader/ && chown 1000:100 /jdownloader/
+RUN mkdir -p -m 777 /init/ && chown 1000:100 /init/
 
-COPY --chown=1000:100 --chmod=777 ./src/ /jdownloader/
+COPY --chown=1000:100 --chmod=777 ./src/ /init/
 
-WORKDIR /jdownloader/
+WORKDIR /init/
 
 ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/Dockerfile/debian.Dockerfile
+++ b/Dockerfile/debian.Dockerfile
@@ -16,7 +16,7 @@ ENV LOG_FILE="/dev/null"
 ENV JAVA_OPTIONS=""
 ENV UMASK=""
 
-ARG OPENJDK="openjdk-17-jre-headless"
+ARG OPENJDK="openjdk-21-jre-headless"
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
@@ -30,9 +30,10 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 RUN mkdir -p -m 777 /jdownloader/ && chown 1000:100 /jdownloader/
+RUN mkdir -p -m 777 /init/ && chown 1000:100 /init/
 
-COPY --chown=1000:100 --chmod=777 ./src/ /jdownloader/
+COPY --chown=1000:100 --chmod=777 ./src/ /init/
 
-WORKDIR /jdownloader/
+WORKDIR /init/
 
 ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/Dockerfile/ubuntu.Dockerfile
+++ b/Dockerfile/ubuntu.Dockerfile
@@ -29,9 +29,10 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 RUN mkdir -p -m 777 /jdownloader/ && chown 1000:100 /jdownloader/
+RUN mkdir -p -m 777 /init/ && chown 1000:100 /init/
 
-COPY --chown=1000:100 --chmod=777 ./src/ /jdownloader/
+COPY --chown=1000:100 --chmod=777 ./src/ /init/
 
-WORKDIR /jdownloader/
- 
+WORKDIR /init/
+
 ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/build.md
+++ b/build.md
@@ -16,7 +16,7 @@
 
 ### Debian
 
-    docker build -t debian-openjdk17 -f ./Dockerfile/debian.Dockerfile --build-arg OPENJDK="openjdk-17-jre-headless" .
+    docker build -t debian-openjdk21 -f ./Dockerfile/debian.Dockerfile --build-arg OPENJDK="openjdk-21-jre-headless" .
 
 ## Build and push for all architectures
 

--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -61,8 +61,10 @@ if [ -n "$UMASK" ]; then
     umask $UMASK
 fi
 
-JDownloaderJarFile="JDownloader.jar"
-JDownloaderJarUrl="installer.jdownloader.org/$JDownloaderJarFile"
+JDownloaderJarFileName="JDownloader.jar"
+JDownloaderJarFile="/jdownloader/$JDownloaderJarFileName"
+JDownloaderDir="/jdownloader"
+JDownloaderJarUrl="installer.jdownloader.org/$JDownloaderJarFileName"
 
 group "Check \"$JDownloaderJarFile\""
 
@@ -71,11 +73,11 @@ unzip -t $JDownloaderJarFile &> /dev/null
 unzipExitCode=$?
 if [ "$unzipExitCode" -ne 0 ]; then
     log "Delete any existing JDownloader installation files"
-    rm -f -r $JDownloaderJarFile Core.jar ./tmp ./update
+    rm -f -r $JDownloaderJarFile $JDownloaderDir/Core.jar $JDownloaderDir/tmp $JDownloaderDir/update
 fi
 
 # If the JDownloader jar file does not exist
-if [ ! -f "./$JDownloaderJarFile" ]; then
+if [ ! -f "$JDownloaderJarFile" ]; then
     downloadFile "https://$JDownloaderJarUrl" "$JDownloaderJarFile"
     downloadFileExitCode=$?
     if [ $downloadFileExitCode -ne 0 ]; then
@@ -92,20 +94,20 @@ groupEnd
 group "Setup JDownloader"
 
 # Create directory logs if applicable
-if [ ! -d "./logs/" ]; then
-    log "Create directory \"./logs/\""
-    mkdir -p "./logs/"
+if [ ! -d "$JDownloaderDir/logs/" ]; then
+    log "Create directory \"$JDownloaderDir/logs/\""
+    mkdir -p "$JDownloaderDir/logs/"
 fi
 
-installFile "org.jdownloader.extensions.eventscripter.EventScripterExtension.json" "./cfg/"
-installFile "org.jdownloader.extensions.eventscripter.EventScripterExtension.scripts.json" "./cfg/"
-installFile "org.jdownloader.settings.GeneralSettings.json" "./cfg/"
-installFile "org.jdownloader.api.myjdownloader.MyJDownloaderSettings.json" "./cfg/"
-installFile "extensions.requestedinstalls.json" "./update/versioninfo/JD/"
+installFile "org.jdownloader.extensions.eventscripter.EventScripterExtension.json" "$JDownloaderDir/cfg/"
+installFile "org.jdownloader.extensions.eventscripter.EventScripterExtension.scripts.json" "$JDownloaderDir/cfg/"
+installFile "org.jdownloader.settings.GeneralSettings.json" "$JDownloaderDir/cfg/"
+installFile "org.jdownloader.api.myjdownloader.MyJDownloaderSettings.json" "$JDownloaderDir/cfg/"
+installFile "extensions.requestedinstalls.json" "$JDownloaderDir/update/versioninfo/JD/"
 
 if [ -n "$JD_EMAIL" ]; then
     log "Set JDownloader email"
-    replaceJsonValue "./cfg/org.jdownloader.api.myjdownloader.MyJDownloaderSettings.json" "email" "$JD_EMAIL"
+    replaceJsonValue "$JDownloaderDir/cfg/org.jdownloader.api.myjdownloader.MyJDownloaderSettings.json" "email" "$JD_EMAIL"
     exitCode=$?
     if [ $exitCode -ne 0 ]; then
         fatal $exitCode "Set JDownloader email failed"
@@ -114,7 +116,7 @@ fi
 
 if [ -n "$JD_PASSWORD" ]; then
     log "Set JDownloader password"
-    replaceJsonValue "./cfg/org.jdownloader.api.myjdownloader.MyJDownloaderSettings.json" "password" "$JD_PASSWORD"
+    replaceJsonValue "$JDownloaderDir/cfg/org.jdownloader.api.myjdownloader.MyJDownloaderSettings.json" "password" "$JD_PASSWORD"
     exitCode=$?
     if [ $exitCode -ne 0 ]; then
         fatal $exitCode "Set JDownloader password failed"
@@ -123,7 +125,7 @@ fi
 
 if [ -n "$JD_DEVICENAME" ]; then
     log "Set JDownloader devicename"
-    replaceJsonValue "./cfg/org.jdownloader.api.myjdownloader.MyJDownloaderSettings.json" "devicename" "$JD_DEVICENAME"
+    replaceJsonValue "$JDownloaderDir/cfg/org.jdownloader.api.myjdownloader.MyJDownloaderSettings.json" "devicename" "$JD_DEVICENAME"
     exitCode=$?
     if [ $exitCode -ne 0 ]; then
         fatal $exitCode "Set JDownloader device name failed"


### PR DESCRIPTION
This would leave only JDownloader in `/jdownloader` and creates the ability to mount the whole folder `jdownloader` as a volume. This is useful for using `podman` with `quadlet`.
Anyone else can keep their volumes like before.

Fix #53 